### PR TITLE
HaikuWebSearch: add Preferences window and Settings button

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ SRCS = \
 	 App.cpp  \
 	 MainWindow.cpp  \
 	 SearchView.cpp  \
+	 PrefsWindow.cpp
 
 
 #	Specify the resource definition files to use. Full or relative paths can be

--- a/PrefsWindow.cpp
+++ b/PrefsWindow.cpp
@@ -1,0 +1,97 @@
+#include "PrefsWindow.h"
+
+#include <Box.h>
+#include <Button.h>
+#include <GroupLayoutBuilder.h>
+#include <LayoutBuilder.h>
+#include <RadioButton.h>
+
+#include "SearchView.h"
+
+
+enum {
+	MSG_PREFERRED = 'PRFD',
+	MSG_DEFAULT = 'DFLT'
+};
+
+static const char* engines[] = {
+	"Google", "Bing", "Duckduckgo", "Baidu", "Yandex",
+	"Gigablast", "Sogou", "Qwant", "Naver", "Good Search"
+};
+static const unsigned numEngines = sizeof engines / sizeof engines[0];
+
+static BRadioButton* radioButtons[numEngines];
+
+
+PrefsWindow::PrefsWindow(const char* preferredEngine)
+	:
+	BWindow(BRect(0, 0, 0, 0), "Preferences", B_TITLED_WINDOW,
+		B_WILL_DRAW | B_AUTO_UPDATE_SIZE_LIMITS)
+{
+	BMessage msg(MSG_PREFERRED);
+	msg.AddInt32("index", 0);
+
+	int32 index;
+
+	for (index = 0; index < numEngines; index++) {
+		msg.ReplaceInt32("index", index);
+		radioButtons[index] = new BRadioButton(engines[index],
+			new BMessage(msg));
+	}
+
+	for (index = 0; index < numEngines - 1; index++)
+		if (strcmp(engines[index], preferredEngine) == 0)
+			break;
+
+	radioButtons[index]->SetValue(B_CONTROL_ON);
+
+	msg = BMessage(MSG_DEFAULT);
+	BButton* defaultButton = new BButton("Default", new BMessage(msg));
+
+	BLayoutBuilder::Group<>(this, B_VERTICAL, B_USE_ITEM_SPACING)
+		.SetInsets(B_USE_ITEM_SPACING, B_USE_ITEM_SPACING,
+			B_USE_ITEM_SPACING, B_USE_ITEM_SPACING)
+		.AddGroup(B_HORIZONTAL, B_USE_ITEM_SPACING)
+			.AddGroup(B_VERTICAL, B_USE_ITEM_SPACING)
+				.Add(radioButtons[0])
+				.Add(radioButtons[1])
+				.Add(radioButtons[2])
+				.Add(radioButtons[3])
+				.Add(radioButtons[4])
+				.End()
+			.AddStrut(10)
+			.AddGroup(B_VERTICAL, B_USE_ITEM_SPACING)
+				.Add(radioButtons[5])
+				.Add(radioButtons[6])
+				.Add(radioButtons[7])
+				.Add(radioButtons[8])
+				.Add(radioButtons[9])
+				.End()
+			.End()
+		.Add(defaultButton)
+		.End();
+
+	CenterOnScreen();
+	Show();
+}
+
+
+void
+PrefsWindow::MessageReceived(BMessage* msg)
+{
+	int32 index;
+
+	switch (msg->what) {
+		case MSG_PREFERRED:
+			msg->FindInt32("index", &index);
+			fPreferredEngine = engines[index];
+			break;
+		case MSG_DEFAULT:
+			index = numEngines - 1;
+			radioButtons[index]->SetValue(B_CONTROL_ON);
+			fPreferredEngine = engines[index];
+			break;
+		default:
+			BWindow::MessageReceived(msg);
+	}
+}

--- a/PrefsWindow.h
+++ b/PrefsWindow.h
@@ -1,0 +1,18 @@
+#ifndef PREFS_WINDOW_H
+#define PREFS_WINDOW_H
+
+#include <Window.h>
+
+class PrefsWindow : public BWindow
+{
+public:
+			PrefsWindow(const char* preferredEngine);
+	void	MessageReceived(BMessage* msg);
+
+	const char* PreferredEngine() const { return fPreferredEngine; }
+
+private:
+	const char* fPreferredEngine;
+};
+
+#endif

--- a/SearchView.h
+++ b/SearchView.h
@@ -16,6 +16,8 @@
 #include <string>
 #include <map>
 
+#include "PrefsWindow.h"
+
 #define HAIKU_WEBSEARCH_DIRECTORY "HaikuWebSearch"
 #define HAIKU_WEBSEARCH_ENGINES	  "engines"
 
@@ -27,6 +29,7 @@ class BPopUpMenu;
 
 enum
 {
+	MSG_PREFS		= 'PREF',
 	MSG_SEARCH 		= 'SEAR',
 	MSG_POPUPMENU	= 'PUMU',
 	MSG_CHANGEENG	= 'CGEG'
@@ -48,6 +51,7 @@ public:
 	
 	
 private:
+	PrefsWindow*		fPrefsWindow;
 	SearchView_sub      *subView;
 	std::map<std::string, std::string> search_engines;
 	std::string			current_engine;
@@ -58,9 +62,16 @@ class SearchView_sub : public BView
 {
 public:
 		SearchView_sub(BRect frame);
-		
+
 		BTextControl 		*fTextControl;
 		SearchView_btn		*fBtnSearch;
+};
+
+class PrefsButton : public BButton
+{
+public:
+		PrefsButton();
+virtual void	MouseDown(BPoint point);
 };
 
 class SearchView_btn : public BView


### PR DESCRIPTION
Added the Settings button to the search view. It opens the Preferences
window, which shows 10 search engines and a default button for Good
Search.

![screen shot 2018-01-17 at 6 50 41 am](https://user-images.githubusercontent.com/6434360/35048744-ca9d55ba-fb52-11e7-90c4-e54dbce349e8.png)